### PR TITLE
WDP-1905-01-2

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -87,19 +87,19 @@ header {
         }
 
         .cart-counter {
-          width: 28px;
+          min-width: 28px;
           height: 27px;
           border-radius: 14px;
           background-color: $header-bg;
           display: flex;
           align-items: center;
-          justify-content: center;
           font-size: 14px;
+          padding-left: 10px;
           color: rgb(224, 227, 237);
           position: absolute;
           top: 50%;
-          right: 0;
-          transform: translate(50%, -50%);
+          left: 75%;
+          transform: translateY(-50%);
         }
 
         &:hover {


### PR DESCRIPTION
Problem był z wyświetlaniem ilości produktów w koszyku, powyżej liczb dwucyfrowych. Powinno wyświetlać prawidłowo do liczb 5-cyfrowych.
Zmieniono style .cart counter 
z 'width: 28px' na max 'min-width: 28px;
z left '0' na '75%'
Usunięto : 
'translateX (-50%) oraz 'justify-content: center';
Dodano 'padding-left: 10px;'