### PR TITLE
Wdp190501-16

### DIFF
--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -2,7 +2,7 @@
   <div class="footer-menu">
     <div class="container">
       <div class="row">
-        <div class="col">
+        <div class="col-6 col-md-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -13,7 +13,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-6 col-md-3">
           <div class="menu-wrapper">
             <h6>My account</h6>
             <ul>
@@ -24,7 +24,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-6 col-md-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -35,7 +35,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-6 col-md-3">
           <div class="menu-wrapper">
             <h6>Orders</h6>
             <ul>
@@ -45,19 +45,19 @@
               <li><a href="#">Shipping</a></li>
             </ul>
           </div>
-          <img src="./images/cards.png" />
+          <img class="img-fluid" src="./images/cards.png" />
         </div>
       </div>
     </div>
   </div>
   <div class="bottom-bar">
     <div class="container">
-      <div class="row align-items-center">
-        <div class="col"></div>
-        <div class="col copyright text-center">
+      <div class="row align-items-center justify-items-center">
+        <div class="col-12 col-lg-4"></div>
+        <div class="col col-lg-4 copyright text-left">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
-        <div class="col socialmedia text-right">
+        <div class="col col-lg-4 socialmedia text-right">
           <ul>
             <li>
               <a href="#"><i class="fab fa-twitter"></i></a>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -52,7 +52,7 @@
   </div>
   <div class="bottom-bar">
     <div class="container">
-      <div class="row align-items-center justify-items-center">
+      <div class="row align-items-center">
         <div class="col-12 col-lg-4"></div>
         <div class="col col-lg-4 copyright text-left">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -78,3 +78,19 @@ footer {
     }
   }
 }
+@media (max-width: 576px) {
+  footer {
+    .footer-menu .menu-wrapper {
+      ul li a {
+        font-size: 12px;
+      }
+    }
+    .bottom-bar {
+      .socialmedia {
+        ul li {
+          margin-left: 3px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Zadanie: 
   Górna partia stopki (szare tło, linki ikony metod płatności) na tabletach się mieści, ale na mniejszych 
   ekranach chce żeby były po dwie sekcje na szerokość, a jak w najmniejszych rozdzielczościach nie 
   będą się mieścić, to nawet 1 na szerokość (tylko w tych najmniejszych). 

   W tym dolnym pasku Klient chce żeby na tablecie copyright był do lewej, a socjalki do prawej. Tam jest 
   obecnie specjalnie zostawione miejsce po lewej, w którym na razie niczego nie ma, ale Klient prosił o 
   uwzględnienie że może być coś dodane i wtedy na tabletach to coś ma być wyśrodkowane i na całą 
   szerokość (nad copyright i socjalkami)

Rozwiązanie :
   dodanie klas col-* na odpowiednich elementach, oraz ostylowanie stopki dla urządzeniach mobilnych.